### PR TITLE
Debug mathlive function recognition

### DIFF
--- a/src/utils/latexUtils.ts
+++ b/src/utils/latexUtils.ts
@@ -15,6 +15,12 @@ export const latexToPlainText = (latex: string): string => {
     .replace(/\\frac\{([^}]+)\}\{([^}]+)\}/g, '$1/$2')
     .replace(/\\sqrt\{([^}]+)\}/g, 'sqrt($1)')
     .replace(/\\sqrt\[([^\]]+)\]\{([^}]+)\}/g, '$2^(1/$1)')
+    // Handle Unicode square root symbol
+    .replace(/√\{([^}]+)\}/g, 'sqrt($1)')
+    .replace(/√([0-9]+(?:\.[0-9]+)?)/g, 'sqrt($1)')
+    .replace(/√\(([^)]+)\)/g, 'sqrt($1)')
+    // Handle direct Unicode square root without delimiters
+    .replace(/√/g, 'sqrt')
     .replace(/\^?\{([^}]+)\}/g, '^$1')
     .replace(/_?\{([^}]+)\}/g, '_$1')
     
@@ -61,8 +67,15 @@ export const plainTextToLatex = (text: string): string => {
     .replace(/_(\d+)/g, '_{$1}')
     .replace(/_(\([^)]+\))/g, '_{$1}')
     
-    // Convert sqrt
+    // Convert mathematical functions
     .replace(/sqrt\(([^)]+)\)/g, '\\sqrt{$1}')
+    .replace(/cbrt\(([^)]+)\)/g, '\\sqrt[3]{$1}')
+    .replace(/sin\(([^)]+)\)/g, '\\sin($1)')
+    .replace(/cos\(([^)]+)\)/g, '\\cos($1)')
+    .replace(/tan\(([^)]+)\)/g, '\\tan($1)')
+    .replace(/log\(([^)]+)\)/g, '\\log($1)')
+    .replace(/ln\(([^)]+)\)/g, '\\ln($1)')
+    .replace(/exp\(([^)]+)\)/g, 'e^{$1}')
     
     // Convert operators
     .replace(/\*/g, '\\cdot ')

--- a/src/utils/mathValidation.ts
+++ b/src/utils/mathValidation.ts
@@ -45,8 +45,11 @@ export function areMathematicallyEquivalent(
     // Convert LaTeX to plain text if needed
     const plainTextAnswer = isLatex(userAnswer) ? latexToPlainText(userAnswer) : userAnswer;
     
+    // Evaluate mathematical functions in the answer
+    const evaluatedAnswer = evaluateMathematicalFunctions(plainTextAnswer);
+    
     // Normalize and parse user answer
-    const normalizedUserAnswer = normalizeAnswer(plainTextAnswer);
+    const normalizedUserAnswer = normalizeAnswer(evaluatedAnswer);
     const userValue = parseFloat(normalizedUserAnswer);
     
     if (isNaN(userValue)) return null;
@@ -68,6 +71,16 @@ export function areMathematicallyEquivalent(
  * Extract the correct answer from a mathematical question
  */
 function extractCorrectAnswer(question: string): number | null {
+  // Handle square root problems
+  const sqrtMatch = question.match(/(?:√|\\sqrt\{|sqrt\()(\d+(?:\.\d+)?)(?:\}|\))?/);
+  if (sqrtMatch) {
+    const number = parseFloat(sqrtMatch[1]);
+    if (!isNaN(number) && number >= 0) {
+      console.log(`[mathValidation] Found square root in question: sqrt(${number}) = ${Math.sqrt(number)}`);
+      return Math.sqrt(number);
+    }
+  }
+
   // Handle division problems (fractions)
   const divisionMatch = question.match(/(\d+(?:\.\d+)?)\s*[÷\/]\s*(\d+(?:\.\d+)?)/);
   if (divisionMatch) {
@@ -339,4 +352,167 @@ function isValidFraction(fraction: string): boolean {
   
   const [numerator, denominator] = fraction.split('/').map(Number);
   return numerator > 0 && denominator > 1 && numerator < 1000 && denominator < 1000;
+}
+
+/**
+ * Evaluate mathematical functions in expressions (sqrt, etc.)
+ */
+function evaluateMathematicalFunctions(expression: string): string {
+  try {
+    console.log('[mathValidation] Evaluating mathematical functions in:', expression);
+    
+    let result = expression;
+    
+    // Handle square root functions
+    result = result.replace(/sqrt\(([^)]+)\)/g, (match, content) => {
+      try {
+        // Handle nested expressions or simple numbers
+        const innerValue = parseFloat(content);
+        if (!isNaN(innerValue) && innerValue >= 0) {
+          const sqrtResult = Math.sqrt(innerValue);
+          console.log(`[mathValidation] sqrt(${innerValue}) = ${sqrtResult}`);
+          return sqrtResult.toString();
+        }
+        return match; // Return original if can't evaluate
+      } catch (error) {
+        console.log('[mathValidation] Error evaluating sqrt:', error);
+        return match;
+      }
+    });
+    
+    // Handle cube root functions
+    result = result.replace(/cbrt\(([^)]+)\)/g, (match, content) => {
+      try {
+        const innerValue = parseFloat(content);
+        if (!isNaN(innerValue)) {
+          const cbrtResult = Math.cbrt(innerValue);
+          console.log(`[mathValidation] cbrt(${innerValue}) = ${cbrtResult}`);
+          return cbrtResult.toString();
+        }
+        return match;
+      } catch (error) {
+        console.log('[mathValidation] Error evaluating cbrt:', error);
+        return match;
+      }
+    });
+    
+    // Handle basic trigonometric functions (in degrees)
+    result = result.replace(/sin\(([^)]+)\)/g, (match, content) => {
+      try {
+        const degrees = parseFloat(content);
+        if (!isNaN(degrees)) {
+          const radians = (degrees * Math.PI) / 180;
+          const sinResult = Math.sin(radians);
+          console.log(`[mathValidation] sin(${degrees}°) = ${sinResult}`);
+          return sinResult.toString();
+        }
+        return match;
+      } catch (error) {
+        console.log('[mathValidation] Error evaluating sin:', error);
+        return match;
+      }
+    });
+    
+    result = result.replace(/cos\(([^)]+)\)/g, (match, content) => {
+      try {
+        const degrees = parseFloat(content);
+        if (!isNaN(degrees)) {
+          const radians = (degrees * Math.PI) / 180;
+          const cosResult = Math.cos(radians);
+          console.log(`[mathValidation] cos(${degrees}°) = ${cosResult}`);
+          return cosResult.toString();
+        }
+        return match;
+      } catch (error) {
+        console.log('[mathValidation] Error evaluating cos:', error);
+        return match;
+      }
+    });
+    
+    result = result.replace(/tan\(([^)]+)\)/g, (match, content) => {
+      try {
+        const degrees = parseFloat(content);
+        if (!isNaN(degrees)) {
+          const radians = (degrees * Math.PI) / 180;
+          const tanResult = Math.tan(radians);
+          console.log(`[mathValidation] tan(${degrees}°) = ${tanResult}`);
+          return tanResult.toString();
+        }
+        return match;
+      } catch (error) {
+        console.log('[mathValidation] Error evaluating tan:', error);
+        return match;
+      }
+    });
+    
+    // Handle logarithmic functions
+    result = result.replace(/log\(([^)]+)\)/g, (match, content) => {
+      try {
+        const innerValue = parseFloat(content);
+        if (!isNaN(innerValue) && innerValue > 0) {
+          const logResult = Math.log10(innerValue);
+          console.log(`[mathValidation] log(${innerValue}) = ${logResult}`);
+          return logResult.toString();
+        }
+        return match;
+      } catch (error) {
+        console.log('[mathValidation] Error evaluating log:', error);
+        return match;
+      }
+    });
+    
+    result = result.replace(/ln\(([^)]+)\)/g, (match, content) => {
+      try {
+        const innerValue = parseFloat(content);
+        if (!isNaN(innerValue) && innerValue > 0) {
+          const lnResult = Math.log(innerValue);
+          console.log(`[mathValidation] ln(${innerValue}) = ${lnResult}`);
+          return lnResult.toString();
+        }
+        return match;
+      } catch (error) {
+        console.log('[mathValidation] Error evaluating ln:', error);
+        return match;
+      }
+    });
+    
+    // Handle exponential functions
+    result = result.replace(/exp\(([^)]+)\)/g, (match, content) => {
+      try {
+        const innerValue = parseFloat(content);
+        if (!isNaN(innerValue)) {
+          const expResult = Math.exp(innerValue);
+          console.log(`[mathValidation] exp(${innerValue}) = ${expResult}`);
+          return expResult.toString();
+        }
+        return match;
+      } catch (error) {
+        console.log('[mathValidation] Error evaluating exp:', error);
+        return match;
+      }
+    });
+    
+    // Handle power functions (basic case: number^number)
+    result = result.replace(/([0-9.]+)\^([0-9.]+)/g, (match, base, exponent) => {
+      try {
+        const baseNum = parseFloat(base);
+        const expNum = parseFloat(exponent);
+        if (!isNaN(baseNum) && !isNaN(expNum)) {
+          const powResult = Math.pow(baseNum, expNum);
+          console.log(`[mathValidation] ${baseNum}^${expNum} = ${powResult}`);
+          return powResult.toString();
+        }
+        return match;
+      } catch (error) {
+        console.log('[mathValidation] Error evaluating power:', error);
+        return match;
+      }
+    });
+    
+    console.log(`[mathValidation] Function evaluation result: "${expression}" -> "${result}"`);
+    return result;
+  } catch (error) {
+    console.log('[mathValidation] Error in evaluateMathematicalFunctions:', error);
+    return expression; // Return original if evaluation fails
+  }
 }


### PR DESCRIPTION
Enhance mathematical function recognition and evaluation to correctly process and grade inputs like `√25` from MathLive.

Previously, MathLive inputs like `√25` were converted to `sqrt(25)` but not numerically evaluated, causing the system to only recognize the number `25` and ignore the square root operation. This PR introduces a new function evaluation step in the validation pipeline and improves LaTeX conversion to correctly interpret and compute various mathematical functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-5feb1887-698f-4b5d-bcca-a068e2d28ef5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5feb1887-698f-4b5d-bcca-a068e2d28ef5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

